### PR TITLE
Changed links for external javascript files from http to https

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -9,12 +9,12 @@
 		<title></title>
 		<meta name="description" content="">
 		<meta name="viewport" content="width=device-width">
-		<script src="http://code.jquery.com/jquery-1.10.1.min.js"></script>
+		<script src="https://code.jquery.com/jquery-1.10.1.min.js"></script>
 
 		<script type="text/javascript" src="app.js"></script>
-		<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.1/leaflet.css" />
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.1/leaflet.css" />
 		<link rel="stylesheet" href="leaflet.draw.css" />
-		<script src="http://cdn.leafletjs.com/leaflet-0.7.1/leaflet.js?2"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.1/leaflet.js"></script>
 		<script src="leaflet.label-src.js"></script>
 		<script src="leaflet.draw-src.js"></script>
 		<link rel="stylesheet" type="text/css" href="leaflet.label.css"/>

--- a/generator/index.html
+++ b/generator/index.html
@@ -12,7 +12,7 @@
     <title>GeoJSON Maps of the globe</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.1/leaflet.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.1/leaflet.css" />
     <link rel="stylesheet" type="text/css" href="dist/app.css?2014-01-08">
 </head>
 
@@ -141,7 +141,7 @@
         }
         $.getJSON(myGeoJSONPath,function(data){
             var map = L.map('map').setView([39.74739, -105], 4);
-    
+
             L.geoJson(data, {
                 clickable: false,
                 style: myCustomStyle
@@ -185,8 +185,8 @@
         </div>
     </footer>
     <a href="https://github.com/AshKyd/geojson-regions"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
-    <script type="text/javascript" src="http://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <script src="http://cdn.leafletjs.com/leaflet-0.7.1/leaflet.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-2.0.3.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.1/leaflet.js"></script>
     <script type="text/javascript" src="dist/app.min.js?2014-01-08"></script>
 </body>
 


### PR DESCRIPTION
Currently https://geojson-maps.kyd.com.au doesn't work because of 'Mixed Content' errors - https page fails to load http data. This PR replaces all http links to https in generator/index.html and example/index.html.

Unfortunately leaflet's cdn doesn't provide https link. Thats why I found an https version in http://www.cdnjs.com/libraries/leaflet
